### PR TITLE
Add new API versions

### DIFF
--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -34,6 +34,9 @@ class ApiVersion(object):
         cls.define_version(Release("2022-10"))
         cls.define_version(Release("2023-01"))
         cls.define_version(Release("2023-04"))
+        cls.define_version(Release("2023-07"))
+        cls.define_version(Release("2023-10"))
+        cls.define_version(Release("2024-01"))
 
     @classmethod
     def clear_defined_versions(cls):


### PR DESCRIPTION
Update the api_version.py file to include the latest releases of the API: 2023-07, 2023-10 and 2024-01
